### PR TITLE
More powerful patch script

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,13 +16,12 @@ The pcbnew config file content has been split into the sections responsible for 
 
 ## Automatic patcher
 
-You can use patch.py to automatically patch the configuration files. The python script searches for settings that have to be overwritten and appends all new settings to the end of the file.
+An automatic patch script can be used to transfer a colour scheme into your KiCad settings files. Make sure KiCad is closed before using it.
 
-`python3.6 patch.py <patch file> <config file>`
+The script expects the directory containing the colour scheme and the kicad config directory as arguments. Switches are included to disable transfer of a particular part of the scheme definition. (use --help for detailed instructions.) A bakup of your settings files is created before changes are made.
 
-For example:
-
-`python3.6 patch.py ~/kicad-color-schemes/blue-green-dark/pcbnew ~/.config/kicad/pcbnew`
+Example:
+`python3 patch.py ~/kicad-color-schemes/blue-green-dark/ ~/.config/kicad/`
 
 ## eeschema
 

--- a/_help/kit-dev-coldfire-xilinx_5213/kit-dev-coldfire-xilinx_5213.kicad_pcb
+++ b/_help/kit-dev-coldfire-xilinx_5213/kit-dev-coldfire-xilinx_5213.kicad_pcb
@@ -1,4 +1,4 @@
-(kicad_pcb (version 20171130) (host pcbnew 5.1.1-8be2ce7~80~ubuntu16.04.1)
+(kicad_pcb (version 20171130) (host pcbnew 5.1.2-f72e74a~84~ubuntu16.04.1)
 
   (general
     (thickness 1.6)

--- a/patch.py
+++ b/patch.py
@@ -1,4 +1,4 @@
-#!/bin/python3.6
+#!/usr/bin/env python3
 import sys, os
 import argparse
 from collections import OrderedDict

--- a/patch.py
+++ b/patch.py
@@ -1,20 +1,100 @@
 #!/bin/python3.6
-import sys
+import sys, os
+import argparse
+from collections import OrderedDict
+from pathlib import Path
 
-patch=open(sys.argv[1], "r").readlines()
-orig=open(sys.argv[2],"r")
-origlines = orig.readlines()
+class ConfigFile():
+    def __init__(self, filepath):
+        self.content = OrderedDict()
+        self.filepath = filepath
+        with open(filepath, 'r') as file:
+            idx = 0
+            for line in file:
+                l = line.strip()
+                if l != '':
+                    try:
+                        key, value = l.split('=', 1)
+                    except:
+                        raise ValueError("line {}: '{}' is of invalid format in config file.".format(idx, l))
+                    self.content.update({key: value})
+                    idx += 1
 
-for idx,oline in enumerate(origlines):
-  osubst = oline.split('=')
-  for idx1,pline in enumerate(patch):
-    psubst = pline.split('=')
-    if osubst[0] == psubst[0]:
-      origlines[idx] = pline
-      patch.pop(idx1)
-origlines += patch
-orig.close
+    def patch(self, patchfile):
+        with open(patchfile, 'r') as file:
+            idx = 0
+            for line in file:
+                l = line.strip()
+                if l == '':
+                    continue
 
-new=open(sys.argv[2],"w")
-new.writelines(origlines)
-new.close
+                try:
+                    key, value = l.split('=')
+                except:
+                    raise ValueError("line {}: '{}' is of invalid format in patch file.".format(idx, l))
+
+                self.content[key] = value
+                idx += 1
+
+    def write(self):
+        with open(self.filepath, 'w') as file:
+            for key, value in self.content.items():
+                print("{}={}".format(key, value), file=file)
+
+parser = argparse.ArgumentParser(description='Patch the KiCad settings file with the given colour scheme.')
+parser.add_argument('config_dir', type=Path, nargs=1,
+                        help='Path to kicad config directory')
+parser.add_argument('scheme_path', type=Path, nargs=1,
+                        help='Path to scheme definition.')
+
+parser.add_argument('-p', '--pcb_disable', action='store_true', help='Disable patching of pcb_new colour definition')
+parser.add_argument('-f', '--footprint_disable', action='store_true', help='Disable patching of footprint editor colour definition')
+parser.add_argument('-e', '--eeschema_disable', action='store_true', help='Disable patching of eeschema and symbol editor colour definition')
+
+args = parser.parse_args()
+
+
+if args.pcb_disable and args.footprint_disable and args.eeschema_disable:
+    print("All definitions disabled. Nothing to do. (Use --help for instructions.)")
+    exit()
+
+if not args.config_dir[0].is_dir():
+    print("'{}' expected to be the kicad config directory but it is not a directory or does not exist. (Use --help for instructions.)".format(args.config_dir[0]))
+    exit()
+
+if not args.scheme_path[0].is_dir():
+    print("'{}' expected to be the colour scheme definition directory but it is not a directory or does not exist. (Use --help for instructions.)".format(args.scheme_path[0]))
+
+if not args.eeschema_disable:
+    ee_patch = args.scheme_path[0] / 'eeschema'
+    if not ee_patch.is_file():
+        print("Scheme does not contain a definition for EESchema, skipped.")
+    else:
+        print("Updating EESchema configuration.")
+        eeschema_handler = ConfigFile(args.config_dir[0] / 'eeschema')
+        eeschema_handler.patch(ee_patch)
+        eeschema_handler.write()
+
+if args.pcb_disable and args.footprint_disable:
+    print("Done")
+    exit()
+
+pcb_handler = ConfigFile(args.config_dir[0] / 'pcbnew')
+
+if not args.pcb_disable:
+    pcb_patch = args.scheme_path[0] / 'pcbnew'
+    if not pcb_patch.is_file():
+        print("Scheme does not contain a definition for pcb_new, skipped.")
+    else:
+        print("Updating pcb_new configuration.")
+        pcb_handler.patch(pcb_patch)
+
+if not args.footprint_disable:
+    fpe_patch = args.scheme_path[0] / 'footprint_editor'
+    if not pcb_patch.is_file():
+        print("Scheme does not contain a definition for the footprint editor, skipped.")
+    else:
+        print("Updating footprint editor configuration.")
+        pcb_handler.patch(fpe_patch)
+
+pcb_handler.write()


### PR DESCRIPTION
The patch script was quite basic.

This now allows to simply specify the config directory and the scheme directory and everything will be updated at once (with flags for disabling specific definitions)
It also uses the argparse class which means we now have documentation via the --help option.
And error handling.

---

Edit: A possible future improvement would be the option to run it in reverse to allow it to create definition files.