### PR TITLE
Update Nord version to prevent JSON parse error

### DIFF
--- a/nord/nord.json
+++ b/nord/nord.json
@@ -139,7 +139,7 @@
   "meta": {
     "filename": "nord",
     "name": "nord",
-    "version": 0
+    "version": 1
   },
   "schematic": {
     "background": "rgb(236, 239, 244)",


### PR DESCRIPTION
Recent KiCad nightlies do not seem to play nicely with a version number of 0 for color themes. This is the build I'm using for reference:

> Version: (5.99.0-11076-g4c8a4e3d47), release build

Copying the Nord theme into the KiCad 6 `colors` folder causes a crash with the following message:

![image](https://user-images.githubusercontent.com/7550606/124401244-287b8980-dcdd-11eb-80b3-ac3bac7c844c.png)

Updating the theme version corrects this, and Nord appears to load correctly after this change:

![image](https://user-images.githubusercontent.com/7550606/124401320-a2ac0e00-dcdd-11eb-8125-01211babfe4c.png)

